### PR TITLE
Fix for csearch

### DIFF
--- a/gister.sh
+++ b/gister.sh
@@ -133,7 +133,7 @@ get_paste() {
 
 update_csearch_index() {
   export CSEARCHINDEX=$gisthome/.csearchindex
-  cindex
+  cindex $gisthome/tree
 }
 
 publish() {


### PR DESCRIPTION
The index wasn't generated in update_csearch_index because the directory path wasn't provided to cindex.

cindex -> cindex $gisthome/tree